### PR TITLE
Fix issue with confirmation not showing anything to the end user.

### DIFF
--- a/desjardins.php
+++ b/desjardins.php
@@ -242,13 +242,16 @@ class Desjardins extends PaymentModule
 
 	public function hookOrderConfirmation($params)
 	{
-		if (!Tools::getIsset($params['objOrder']) || ($params['objOrder']->module != $this->name))
-				return false;
+		if (!isset($params['objOrder']) || ($params['objOrder']->module != $this->name))
+			return false;
 
-		if ($params['objOrder'] && Validate::isLoadedObject($params['objOrder']) && Tools::getIsset($params['objOrder']->valid))
-				$this->smarty->assign('desjardins_order',
-					array('reference' => Tools::getIsset($params['objOrder']->reference) ? $params['objOrder']->reference : '#'.sprintf('%06d',
-								$params['objOrder']->id), 'valid' => $params['objOrder']->valid));
+		if ($params['objOrder'] && Validate::isLoadedObject($params['objOrder']) && isset($params['objOrder']->valid)) {
+			$this->smarty->assign('desjardins_order',
+				array(
+					'reference' => isset($params['objOrder']->reference) ? $params['objOrder']->reference : '#' . sprintf('%06d',
+							$params['objOrder']->id), 'valid' => $params['objOrder']->valid)
+			);
+		}
 
 		return $this->display(__FILE__, 'order-confirmation.tpl');
 	}


### PR DESCRIPTION
Tools::getIsset() is used to check if the key is set in the GET or POST, this was always returning false and thus showing an empty page to the end user.
